### PR TITLE
Add feed auto discovery links

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,6 +168,7 @@ pre .p, pre .nb, pre .nv {
   color: #485c64;
 }
   </style>
+  <link rel="alternate" type="application/atom+xml" title="stylefruits tech" href="/feed.xml" />
 </head>
 <body>
   <header>


### PR DESCRIPTION
You're missing the RSS auto discovery meta links on all your pages, but you're already generating a working Atom feed.

Repo contains the generated output only, so this PR is only an example of what to add the original template. You know, so adding your blog in RSS readers is easier.
